### PR TITLE
fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,7 +90,7 @@ async def on_message(message):
                         roles = discord.utils.get(message.guild.roles, id=role.id)
                         await message.author.remove_roles(roles)
                 await message.author.add_roles(role)
-                await message.channel.send(f"Congrats {message.author.mention}! You have been given the **{levels_roles[levels_author['level']]}** role!")
+                await message.channel.send(f"Congrats {message.author.mention}! You have been given the **{role.name}** role!")
 
 @bot.event
 async def on_member_update(before, after):


### PR DESCRIPTION
This pr fixes the issue with role mentions. When you level up and earn a role, its ID is displayed. With these changes, the role's name should be displayed instead.
![imagen](https://github.com/Pverte/fidiscord/assets/83553548/663fffc3-0f94-4774-bfc7-fade99e8364f)
